### PR TITLE
Add a dependency to cl-lib for Emacs < 24.3

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -5,7 +5,7 @@
 ;; Author: Oleh Krehel <ohwoeowho@gmail.com>
 ;; URL: https://github.com/abo-abo/avy
 ;; Version: 0.1.0
-;; Package-Requires: ((emacs "24.1"))
+;; Package-Requires: ((emacs "24.1") (cl-lib "0.5"))
 ;; Keywords: point, location
 
 ;; This file is part of GNU Emacs.


### PR DESCRIPTION
cl-lib was introduced in Emacs 24.3. On older Emacs versions we have to
install it from GNU ELPA.