### PR TITLE
Fix `avy-goto-subword-0' leading chars ordering

### DIFF
--- a/avy-jump.el
+++ b/avy-jump.el
@@ -368,15 +368,17 @@ should return true."
     (let ((case-fold-search nil)
           candidates)
       (avy-dowindows arg
-        (let ((ws (window-start)))
+        (let ((ws (window-start))
+              candidates-window)
           (save-excursion
             (goto-char (window-end (selected-window) t))
             (subword-backward)
             (while (> (point) ws)
               (when (or (null predicate)
                         (and predicate (funcall predicate)))
-                (push (cons (point) (selected-window)) candidates))
-              (subword-backward)))))
+                (push (cons (point) (selected-window)) candidates-window))
+              (subword-backward)))
+          (setq candidates (nconc candidates candidates-window))))
       (avy--goto
        (avy--process candidates (avy--style-fn avy-goto-word-style))))))
 


### PR DESCRIPTION
* avy-jump.el (avy-dowindows): Add an argument `reverse' for run body in
  reversed window list.

Fixed #14.

According to `window-list' documentation, the selected window
will appear on the first item in the list. So I revert e931071.

In `avy-goto-subword-0', the candidates had been collected in natural
order per window. If we traverse in reversed windows list, the leading
char will be in correct order across multiple windows.