### PR TITLE
Style de-bruijn which uses De Bruijn seqs for paths

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -203,7 +203,13 @@ When nil, punctuation chars will not be matched.
                                     (pop db-seq)))))
       (while matches
         (let* ((cur (car matches))
-               (pos (caar cur))
+               (pos (cond
+                     ;; ace-window has matches of the form (pos . window)
+                     ((integerp (car cur)) (car cur))
+                     ;; avy jump functions have matches of the form ((start
+                     ;; . end) . window)
+                     ((consp (car cur))    (caar cur))
+                     (t (error "Unexpected match representation: %s" cur))))
                (win (cdr cur))
                (path (if prev-pos
                          (let ((diff (if (eq win prev-win)


### PR DESCRIPTION
Already implements Oleh's suggestions in #5.

The new overlay function `avy--overlay-de-bruijn` suggested by @abo-abo in https://github.com/abo-abo/avy/issues/5#issuecomment-105446528 doesn't work completely correct yet.  When there are adjacent matches like `xx` or `xox` when trying to jump to `x` occurrences, only the sequence of the first match is shown completely.  One would expect that both are shown (and their first chars highlighted in blue) because the parts in which they overlap are identical anyhow.