### PR TITLE
Considers letter case only if given Upcase letter

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -549,8 +549,13 @@ Each element of the list is ((BEG . END) . WND)
 When PRED is non-nil, it's a filter for matching point positions.
 When GROUP is non-nil, (BEG . END) should delimit that regex group."
   (setq group (or group 0))
-  (let ((case-fold-search avy-case-fold-search)
-        candidates)
+  (let*
+      ((last-char (substring regex -1 nil))
+       (case-fold-search (or avy-case-fold-search
+                             (not (string= last-char (upcase last-char)))))
+       candidates)
+      ;; ((case-fold-search avy-case-fold-search)
+      ;;  candidates)
     (avy-dowindows nil
       (let ((we (or end (window-end (selected-window) t))))
         (save-excursion


### PR DESCRIPTION
Hello,

I've changed things a bit so that when `avy-case-fold-search` is set to `nil` the jump will behave like **isearch**. E.g. jumping to 'b' targets lower-case and upper-case 'b', and 'B' only targets upper-case.

Let me know if you find this useful and/or if should be done differently.
