### PR TITLE
Improve avy-goto-char-timer so that it may read 1 or many chars

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -1036,19 +1036,30 @@ ARG lines can be used."
 (defcustom avy-timeout-seconds 0.5
   "How many seconds to wait for the second char.")
 
+(defun avy--read-string-timer ()
+  "Read as many chars as possible and return them as string.
+At least one char must be read, and then repeatedly one next char
+may be read if it is entered before `avy-timeout-seconds'."
+  (let ((str "") char)
+    (while (setq char (read-char (format "char%s: "
+                                         (if (string= str "")
+                                             str
+                                           (format " (%s)" str)))
+                                 t
+                                 (and (not (string= str ""))
+                                      avy-timeout-seconds)))
+      (setq str (concat str (list char))))
+    str))
+
 ;;;###autoload
 (defun avy-goto-char-timer (&optional arg)
-  "Read one or two consecutive chars and jump to the first one.
+  "Read one or many consecutive chars and jump to the first one.
 The window scope is determined by `avy-all-windows' (ARG negates it)."
   (interactive "P")
-  (let ((c1 (read-char "char 1: " t))
-        (c2 (read-char "char 2: " t avy-timeout-seconds)))
+  (let ((str (avy--read-string-timer)))
     (avy-with avy-goto-char-timer
       (avy--generic-jump
-       (regexp-quote
-        (if c2
-            (string c1 c2)
-          (string c1)))
+       (regexp-quote str)
        arg
        avy-style))))
 


### PR DESCRIPTION
Now you can use avy-goto-char-timer and type as many chars as you want
given each char comes before avy-timeout-seconds (and the very first
char is mandatory, i.e., there is no timeout for the first one).