### PR TITLE
avy.el (avy-goto-line): fix for narrowed regions

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -1070,8 +1070,10 @@ Otherwise, forward to `goto-line' with ARG."
                                "Goto line: " (string char))))
                     (when line
                       (avy-push-mark)
-                      (goto-char (point-min))
-                      (forward-line (1- (string-to-number line)))
+                      (save-restriction
+                        (widen)
+                        (goto-char (point-min))
+                        (forward-line (1- (string-to-number line))))
                       (throw 'done 'exit))))))
              (r (avy--line (eq arg 4))))
         (unless (eq r t)


### PR DESCRIPTION
When 'avy-goto-line' is called with numbered argument, it tries to mimic
behaviour of 'goto-line'. However, if some part of text is hidden by
narrowing, 'avy-goto-line' failed to account for that.

This patch temporarily disables narrowing, jumps on line and then
restores narrowing, just like 'goto-line' does.

Fixes #122 