### PR TITLE
Add case fold search to avy-goto-char-timer

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -1206,7 +1206,7 @@ read string immediately instead of waiting for another char for
 `avy-timeout-seconds'.
 The format of the result is the same as that of `avy--regex-candidates'.
 This function obeys `avy-all-windows' setting."
-  (let ((str "") char break overlays regex)
+  (let ((str "") char break overlays regex case-fold-search)
     (unwind-protect
          (progn
            (while (and (not break)
@@ -1242,6 +1242,8 @@ This function obeys `avy-all-windows' setting."
                                   (window-end (selected-window) t)))
                      (save-excursion
                        (goto-char (car pair))
+                       (setq case-fold-search (or avy-case-fold-search
+                              (string= str (downcase str))))
                        (setq regex (regexp-quote str))
                        (while (re-search-forward regex (cdr pair) t)
                          (unless (get-char-property (1- (point)) 'invisible)


### PR DESCRIPTION
`avy-goto-char-timer` does not call `avy--regex-candidates` which is where the code for case fold search is.