### PR TITLE
Add avy-action-ispell to avy.el

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -522,6 +522,17 @@ Set `avy-style' according to COMMMAND as well."
    (kill-region pt (point))
    (just-one-space))
   (message "Killed: %s" (current-kill 0)))
+  
+(defun avy-action-ispell (pt)
+  "Auto correct word at PT."
+  (save-excursion
+    (goto-char pt)
+    (if (looking-at-p "\\b")
+        (ispell-word)
+      (progn
+        (backward-word)
+        (when (looking-at-p "\\b")
+          (ispell-word))))))
 
 (defun avy--process (candidates overlay-fn)
   "Select one of CANDIDATES using `avy-read'.


### PR DESCRIPTION
Thank you for creating avy-mode! It is really fun and fast to use. I thought it would be fitting for me to add a convenience function to make spell checking less of a chore. The point should return to its starting location after the desired word is corrected. As is the case for the other avy-action-{something} functions, this function is also added to the avy-dispatch-alist. I hope you'll consider my pull request worthy of  a merge. Thanks again!

Regards,

Emmanuel