### PR TITLE
Add char at window start for avy-goto-subword-0

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -1049,7 +1049,12 @@ should return true."
                             (and predicate (funcall predicate)))
                     (unless (get-char-property (point) 'invisible)
                       (push (cons (point) (selected-window)) window-cands)))
-                  (subword-backward)))
+                  (subword-backward))
+                (and (= (point) ws)
+                     (or (null predicate)
+                         (and predicate (funcall predicate)))
+                     (not (get-char-property (point) 'invisible))
+                     (push (cons (point) (selected-window)) window-cands)))
               (setq candidates (nconc candidates window-cands))))))
       (avy--process candidates (avy--style-fn avy-style)))))
 


### PR DESCRIPTION
We should also add the first character to the candidates if necessary when using `avy-goto-subword-0`.