### PR TITLE
Escape regex metacharacters for standard isearch

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -982,7 +982,9 @@ The window scope is determined by `avy-all-windows' (ARG negates it)."
   (avy-with avy-isearch
     (let ((avy-background nil))
       (avy--process
-       (avy--regex-candidates isearch-string)
+       (avy--regex-candidates (if isearch-regexp
+                                  isearch-string
+                                (regexp-quote isearch-string)))
        (avy--style-fn avy-style))
       (isearch-done))))
 


### PR DESCRIPTION
Hi there,

Just a small issue I noticed: doing an isearch for '[' and then invoking avy-isearch would trigger an error like:

     Invalid regexp: "Unmatched [ or [^"

If we are not doing a regex-based search, escape the search string to avoid these kind of issues.