### PR TITLE
make 'avy-goto-word-1 work with the form-feed character ("^L") (used …

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -1056,18 +1056,20 @@ The window scope is determined by `avy-all-windows' (ARG negates it)."
 The window scope is determined by `avy-all-windows' (ARG negates it)."
   (interactive (list (read-char "char: " t)
                      current-prefix-arg))
-  (avy-with avy-goto-word-1
-    (let* ((str (string char))
-           (regex (cond ((string= str ".")
-                         "\\.")
-                        ((and avy-word-punc-regexp
-                              (string-match avy-word-punc-regexp str))
-                         (regexp-quote str))
-                        (t
-                         (concat
-                          (if symbol "\\_<" "\\b")
-                          str)))))
-      (avy--generic-jump regex arg avy-style beg end))))
+  (if (= char 12)
+      (avy-goto-subword-0 1 (lambda () (= 12 (char-after))))
+    (avy-with avy-goto-word-1
+      (let* ((str (string char))
+             (regex (cond ((string= str ".")
+                           "\\.")
+                          ((and avy-word-punc-regexp
+                                (string-match avy-word-punc-regexp str))
+                           (regexp-quote str))
+                          (t
+                           (concat
+                            (if symbol "\\_<" "\\b")
+                            str)))))
+        (avy--generic-jump regex arg avy-style beg end)))))
 
 ;;;###autoload
 (defun avy-goto-word-1-above (char &optional arg)


### PR DESCRIPTION
…to separate functions in emacs lisp files)

In Emacs Lisp files, especially those which are part of Emacs itself, form-feed characters (<kbd>^L</kbd>) are used to separate definitions or groups of definitions (and are represented in `emacs-lisp-mode` as coloured dividers). It would be convenient to be able to jump to these dividers with `'avy-word`, but this currently doesn't work (even if the character is added to `avy-subword-extra-word-chars`).

This patch to `'avy-goto-word-1` simply tests if the character is `^L` and if so makes an `avy-goto-subword-0` call specifically for `^L`. If not, it proceeds as usual.

Possibly this should be limited to emacs-lisp-mode, but that might complicate things if there were avy `-all-windows` or `-other-window` commands (I can't see any such commands, but it seems like something that may appear later).