### PR TITLE
Add avy-goto-word-0-below and avy-goto-word-0-above

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -1050,12 +1050,28 @@ the visible part of the current buffer following point."
       (isearch-done))))
 
 ;;;###autoload
-(defun avy-goto-word-0 (arg)
+(defun avy-goto-word-0 (arg &optional beg end)
   "Jump to a word start.
 The window scope is determined by `avy-all-windows' (ARG negates it)."
   (interactive "P")
   (avy-with avy-goto-word-0
-    (avy--generic-jump avy-goto-word-0-regexp arg avy-style)))
+    (avy--generic-jump avy-goto-word-0-regexp arg avy-style beg end)))
+
+(defun avy-goto-word-0-above (arg)
+  "Jump to a word start.
+This is a scoped version of `avy-goto-word-0', where the scope is
+the visible part of the current buffer up to point."
+  (interactive "P")
+  (avy-with avy-goto-word-0
+    (avy-goto-word-0 arg (window-start) (point))))
+
+(defun avy-goto-word-0-below (arg)
+  "Jump to a word start.
+This is a scoped version of `avy-goto-word-0', where the scope is
+the visible part of the current buffer following point."
+  (interactive "P")
+  (avy-with avy-goto-word-0
+    (avy-goto-word-0 arg (point) (window-end (selected-window) t))))
 
 ;;;###autoload
 (defun avy-goto-word-1 (char &optional arg beg end symbol)


### PR DESCRIPTION
These commands limit the scope of avy-goto-word-0 to above or below the
point thus save the number of keys required to jump to a certain word.

Fixes #185 