### PR TITLE
Makefile: Add target checkdoc to check documentation guidelines of lisp files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,15 @@ emacs ?= emacs
 
 LOAD = -l avy.el -l avy-test.el
 
-.PHONY: all test clean
+.PHONY: all test clean checkdoc
 
-all: compile test
+all: compile test checkdoc
 
 test:
 	$(emacs) -batch $(LOAD) -f ert-run-tests-batch-and-exit
+
+checkdoc:
+	$(emacs) -batch -l targets/checkdoc.el
 
 compile:
 	$(emacs) -batch -l targets/avy-init.el

--- a/README.md
+++ b/README.md
@@ -113,6 +113,6 @@ The copyright assignment isn't a big deal, it just says that the copyright for y
 
 The basic code style guide is to use `(setq indent-tabs-mode nil)`. It is provided for you in [.dir-locals.el](https://github.com/abo-abo/avy/blob/master/.dir-locals.el), please obey it.
 
-Before submitting the change, run `make compile` and `make test` to make sure that it doesn't introduce new compile warnings or test failures. Also run <kbd>M-x</kbd> `checkdoc` to see that your changes obey the documentation guidelines.
+Before submitting the change, run `make compile` and `make test` to make sure that it doesn't introduce new compile warnings or test failures. Also run `make checkdoc` to see that your changes obey the documentation guidelines.
 
 Use your own judgment for the commit messages, I recommend a verbose style using `magit-commit-add-log`.

--- a/targets/avy-init.el
+++ b/targets/avy-init.el
@@ -22,11 +22,5 @@
 (add-to-list 'load-path default-directory)
 (mapc #'byte-compile-file '("avy.el"))
 (require 'avy)
-(if (fboundp 'checkdoc-file)
-    (checkdoc-file "avy.el")
-  (require 'checkdoc)
-  (with-current-buffer (find-file "avy.el")
-    (checkdoc-current-buffer t)))
-
 (global-set-key (kbd "C-c j") 'avy-goto-char)
 (global-set-key (kbd "C-'") 'avy-goto-char-2)

--- a/targets/checkdoc.el
+++ b/targets/checkdoc.el
@@ -1,0 +1,2 @@
+(checkdoc-file "avy-test.el")
+(checkdoc-file "avy.el")


### PR DESCRIPTION
This PR adds a new target `checkdoc` to the Makefile to check documentation guidelines of lisp files. I think it is more convenient to have its own target for that than doing it together in the `compile` and `run` targets. Thus, I removed the checkdoc code from the file `avy-init` because it became superfluous there.