### PR TITLE
Rephrase misleading instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,11 @@ There are some more commands which you can explore yourself by looking at the co
 
 ### Bindings
 
-You add this to your config to bind some stuff:
+You add this to your config to bind `avy-isearch` to <kbd>C-'</kbd> in `isearch-mode-map`, so that you can select one of the currently visible `isearch` candidates using `avy`.
 
 ```elisp
 (avy-setup-default)
 ```
-
-It will bind, for example, `avy-isearch` to <kbd>C-'</kbd> in `isearch-mode-map`, so that you can select one of the currently visible `isearch` candidates using `avy`.
 
 ### Customization
 


### PR DESCRIPTION
`(avy-setup-default)` only creates a single bind and the README shouldn't make it sound like it does more.

This is code it executes:

```
;;;###autoload
(defun avy-setup-default ()
  "Setup the default shortcuts."
  (eval-after-load "isearch"
    '(define-key isearch-mode-map (kbd "C-'") 'avy-isearch)))
```