### PR TITLE
Add option to display an indented goto line overlay

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -1429,6 +1429,10 @@ Which one depends on variable `subword-mode'."
 
 (defvar visual-line-mode)
 
+(defcustom avy-indent-line-overlay nil
+  "When non-nil, `avy-goto-line' will display the line overlay next to the first non-whitespace character of each line."
+  :type 'boolean)
+
 (defun avy--line-cands (&optional arg beg end bottom-up)
   "Get candidates for selecting a line.
 The window scope is determined by `avy-all-windows'.
@@ -1448,7 +1452,10 @@ When BOTTOM-UP is non-nil, display avy candidates from top to bottom"
                 (push (cons
                        (if (eq avy-style 'post)
                            (line-end-position)
-                         (point))
+                         (save-excursion
+                           (when avy-indent-line-overlay
+                             (skip-chars-forward " \t"))
+                           (point)))
                        (selected-window)) candidates))
               (if visual-line-mode
                   (progn


### PR DESCRIPTION
It may be useful to display the overlay for `avy-goto-line` next to the first
non whitespace character on each line so that your eyes do not have to look
across from the code on the line to the left edge of the buffer.

This commit adds a defcustom for `avy-indent-line-overlay` which enables this
new behavior when non nil.