### PR TITLE
show number of matches so far in prompt

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -1906,7 +1906,8 @@ Otherwise, the whole regex is highlighted."
          (progn
            (while (and (not break)
                        (setq char
-                             (read-char (format "char%s: "
+                             (read-char (format "%d  char%s: "
+                                                (length overlays)
                                                 (if (string= str "")
                                                     str
                                                   (format " (%s)" str)))


### PR DESCRIPTION
Add one more visual feedback to `avy-goto-char-timer`.

When a user edits the candidate str, in particular with the `avy-del-last-char-by` keys, he or she likely focuses attention on the prompt. Showing the number of matches within the prompt as the user types can help determine immediately if the typing has gone wrong.

Without this, the user would have to move attention back and forth between the match highlights and the prompt.