### PR TITLE
Fix: (avy-org-refile-as-child) Don't refile when avy session aborted

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -2014,17 +2014,21 @@ The window scope is determined by `avy-all-windows' (ARG negates it)."
   "Refile current heading as first child of heading selected with `avy.'"
   ;; Inspired by `org-teleport': http://kitchingroup.cheme.cmu.edu/blog/2016/03/18/Org-teleport-headlines/
   (interactive)
-  (let ((rfloc (save-excursion
-                 (let* ((org-reverse-note-order t)
-                        (pos (avy-with avy-goto-line
-                               (avy--generic-jump (rx bol (1+ "*") (1+ space))
-                                                  nil avy-style)
-                               (point)))
-                        (filename (buffer-file-name (or (buffer-base-buffer (current-buffer))
-                                                        (current-buffer)))))
-                   (list nil filename nil pos)))))
-    ;; org-refile must be called outside of the excursion
-    (org-refile nil nil rfloc)))
+  (let* ((org-reverse-note-order t)
+         (marker (save-excursion
+                   (avy-with avy-goto-line
+                     (unless (eq 't (avy--generic-jump (rx bol (1+ "*") (1+ space))
+                                                       nil avy-style))
+                       ;; `avy--generic-jump' returns t when aborted with C-g.
+                       (copy-marker)))))
+         (filename (buffer-file-name (or (buffer-base-buffer (marker-buffer marker))
+                                         (marker-buffer marker))))
+         (rfloc (list nil filename nil pos))
+         ;; Ensure the refiled heading is visible.
+         (org-after-refile-insert-hook (cons #'org-reveal org-after-refile-insert-hook)))
+    (when pos
+      ;; Only attempt refile if avy session was not aborted.
+      (org-refile nil nil rfloc))))
 
 (defun avy-org-goto-heading-timer (&optional arg)
   "Read one or many characters and jump to matching Org headings.


### PR DESCRIPTION
Hi Oleh,

Here's a small fix for this function to avoid an error when the user aborts with `C-g`.

Also, it ensures that the refiled heading is visible afterward.

Thanks.