### PR TITLE
Update readme.md: Add melpa badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![MELPA](https://melpa.org/packages/avy-badge.svg)](https://melpa.org/#/avy)
+[![MELPA Stable](https://stable.melpa.org/packages/avy-badge.svg)](https://stable.melpa.org/#/avy)
+
 ## Introduction
 
 `avy` is a GNU Emacs package for jumping to visible text using a char-based decision tree.  See also [ace-jump-mode](https://github.com/winterTTr/ace-jump-mode) and [vim-easymotion](https://github.com/Lokaltog/vim-easymotion) - `avy` uses the same idea.


### PR DESCRIPTION
This makes it easy to see the current version from the main repository page.

---

I noticed that the latest tagged (stable) release was quite a while ago:
>avy 0.4.0
abo-abo released this on Jan 23, 2016 · 93 commits to master since this release

source: https://github.com/abo-abo/avy/releases

There's an open issue about it:
Please tag a new release #180