### PR TITLE
add customization of function called by avy-action-ispell when flyspell mode is enabled

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -748,6 +748,10 @@ Set `avy-style' according to COMMMAND as well."
 
 (declare-function flyspell-correct-word-before-point "flyspell")
 
+(defcustom avy-flyspell-correct-function #'flyspell-correct-word-before-point
+  "Function called to correct word by `avy-action-ispell' when flyspell-mode is enabled"
+  :type '(string))
+
 (defun avy-action-ispell (pt)
   "Auto correct word at PT."
   (save-excursion
@@ -758,7 +762,7 @@ Set `avy-style' according to COMMMAND as well."
         (line-beginning-position)
         (line-end-position)))
       ((bound-and-true-p flyspell-mode)
-       (flyspell-correct-word-before-point))
+       (funcall avy-flyspell-correct-function))
       ((looking-at-p "\\b")
        (ispell-word))
       (t


### PR DESCRIPTION
We may want use different function to correct words, when we use `avy-action-ispell`, e.g., [flyspell-correct](https://github.com/d12frosted/flyspell-correct) provides several useful interfaces.

Therefore, this pull request provide a option for using another function for correcting.