### PR TITLE
only call goto when avy-action is not set by dispatch action

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -1656,8 +1656,8 @@ The window scope is determined by `avy-all-windows'.
 When ARG is non-nil, do the opposite of `avy-all-windows'.
 BEG and END narrow the scope where candidates are searched.
 When BOTTOM-UP is non-nil, display avy candidates from top to bottom"
-  (let ((avy-action #'identity)
-        (avy-style (if avy-linum-mode
+  (setq avy-action (or avy-action #'identity))
+  (let ((avy-style (if avy-linum-mode
                        (progn
                          (message "Goto line:")
                          'ignore)
@@ -1699,7 +1699,7 @@ Otherwise, forward to `goto-line' with ARG."
                         (forward-line (1- (string-to-number line))))
                       (throw 'done 'exit))))))
              (r (avy--line (eq arg 4))))
-        (unless (eq r t)
+	(when (and (not (eq r t)) (eq avy-action #'identity))
           (avy-action-goto r))))))
 
 ;;;###autoload


### PR DESCRIPTION
hey!
this is my first PR, so feedback is greatly appreciated as I am a new contributor and not super familiar with the codebase. 

I noticed a bug with `avy-goto-line` with the newer dispatch action features.

Example of these bugs:
Let's assume `M-g` is set as `avy-goto-line`.

1. If you press `M-g X dj` (kill-stay), you are expected to kill the line marked by `dj`, and stay at the current position of the point. What actually happens is you kill the line and go to the line as well. This is because `(avy-action-goto r)` is called regardless of whether a dispatch action has been set. 

1. Another example is `M-g t dh` (teleport), which should teleport the selected line at `dh` to the current point position without moving the point. In this situation, the selected line is transported to the point position, but the point is still taken to the original selected line position at `dh`. Again, this is because `(avy-action-goto r)` is called regardless of the action set in `avy-action`

The solution I came up with is to only call `avy-action-goto` when `avy-action` has been left to its default value set in `avy--line` of `#'identity`

Thanks! 
Let me know what you think.