### PR TITLE
Add new customizable variable: avy-restart-on-fail

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -254,6 +254,12 @@ character read.  The default represents `C-h' and `DEL'.  See
 `event-convert-list'."
   :type 'list)
 
+(defcustom avy-restart-on-fail nil
+  "Restart candidate selection if no candidate was matched.
+Set this to t to make candidate selection more tolerant to typos. You
+can still use `C-g' to cancel the selection."
+  :type 'boolean)
+
 (defvar avy-ring (make-ring 20)
   "Hold the window and point history.")
 
@@ -862,8 +868,10 @@ multiple OVERLAY-FN invocations."
         (res (avy--process-1 candidates overlay-fn cleanup-fn)))
     (cond
       ((null res)
-       (message "zero candidates")
-       t)
+       (if avy-restart-on-fail
+           (avy-process original-cands overlay-fn cleanup-fn)
+         (message "zero candidates")
+         t))
       ((eq res 'restart)
        (avy-process original-cands overlay-fn cleanup-fn))
       ;; ignore exit from `avy-handler-function'


### PR DESCRIPTION
This PR adds a new variable called `avy-restart-on-fail`, which makes the candidate selection restart if no candidates were selected. I believe this is useful for users that make typos when trying to make a selection (like me). In these cases, it is faster to redisplay all candidates than to type again the word/chars we want to jump to and then type the chars corresponding to the candidate again.

Edit: note: this was tested with `avy-style` `'words`.