### PR TITLE
avy.el (avy-process): Add autoload

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -856,6 +856,7 @@ Set `avy-style' according to COMMAND as well."
      (when (< pos (1- (length lst)))
        (goto-char (caar (nth (1+ pos) lst)))))))
 
+;;;###autoload
 (defun avy-process (candidates &optional overlay-fn cleanup-fn)
   "Select one of CANDIDATES using `avy-read'.
 Use OVERLAY-FN to visualize the decision overlay.


### PR DESCRIPTION
`avy-process` is used (at least) by emacs-lsp where the package may not yet be loaded yet.

Not sure this is the right way to fix the issue, but it seems like `avy-process` is a public export and thus I thought adding `###autoload` is a good fix. Feel free to decline if using `avy-process` with no previous autoloads invoked is not a supported use of `avy` and we should fix `emacs-lsp` instead.