### PR TITLE
fix: ignore invalid characters

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -2100,8 +2100,10 @@ Otherwise, the whole regex is highlighted."
                ;; Handle ESC
                ((= char 27)
                 (keyboard-quit))
+               ((characterp char)
+                (setq avy-text (concat avy-text (list char))))
                (t
-                (setq avy-text (concat avy-text (list char)))))
+                (message "Not a valid character.")))
              ;; Highlight
              (when (>= (length avy-text) 1)
                (let ((case-fold-search


### PR DESCRIPTION
I have boud avy-goto-char-timer to `C-,`. When pressing `C-,` in the avy prompt, the concat function throws a `wrong-type-argument: characterp` error. We can ignore the error by first checking characterp and print a message in that case. 

Alternatives:
* Ignore completely, print no message
* Signal an error