### PR TITLE
Safe guard in avy-goto-line-* commands

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -1330,9 +1330,11 @@ BEG and END narrow the scope where candidates are searched."
                               c2)))
                      current-prefix-arg
                      nil nil))
-  (when (eq char1 ?)
+  (when (eq char1 ?
+)
     (setq char1 ?\n))
-  (when (eq char2 ?)
+  (when (eq char2 ?
+)
     (setq char2 ?\n))
   (avy-with avy-goto-char-2
     (avy-jump
@@ -1787,7 +1789,7 @@ When BOTTOM-UP is non-nil, display avy candidates from top to bottom"
          (r (avy--line nil (window-start)
                        (line-beginning-position (or offset 1))
 		       bottom-up)))
-    (unless (eq r t)
+    (unless (memq r '(t nil))
       (avy-action-goto r))))
 
 ;;;###autoload
@@ -1804,7 +1806,7 @@ When BOTTOM-UP is non-nil, display avy candidates from top to bottom"
              nil (line-beginning-position (or offset 2))
              (window-end (selected-window) t)
 	     bottom-up)))
-    (unless (eq r t)
+    (unless (memq r '(t nil))
       (avy-action-goto r))))
 
 (defcustom avy-line-insert-style 'above


### PR DESCRIPTION
Added addition check for nil in `avy-goto-line-above` and `avy-goto-line-below`.

This is to prevent cancellation during these commands that will result in an error if `debug-on-error` is set to non-nil.

Note:
There are some unintentional encoding changes (Control-M in lines 1333) that are most likely to be a result of directly editing in github.  