### PR TITLE
visually hint how deep a path is in `at` style

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -1098,9 +1098,10 @@ LEAF is normally ((BEG . END) . WND)."
 PATH is a list of keys from tree root to LEAF.
 LEAF is normally ((BEG . END) . WND)."
   (let* ((path (mapcar #'avy--key-to-char path))
+         (face-index (- (length path) 1))
          (str (propertize
                (string (car (last path)))
-               'face 'avy-lead-face)))
+               'face (nth face-index avy-lead-faces))))
     (avy--overlay
      str
      (avy-candidate-beg leaf) nil


### PR DESCRIPTION
When using `at` style I need to be aware (alert, even) of when a path is going to be done.

This visual hint will help me (and hopefully other people) queue keyboard input for next actions.
- "ok, so this jump takes one key, so once I jump I can copy-a-line, then... "
- "oh, I'll have to input one extra key after this..."