### PR TITLE
Fix two byte-compiler warnings

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -494,8 +494,8 @@ KEYS is the path from the root of `avy-tree' to LEAF."
   "Store the current incomplete path during `avy-read'.")
 
 (defun avy-mouse-event-window (char)
-  "If CHAR is a mouse event, return the window of the event if any or the selected window.
-Return nil if not a mouse event."
+  "Return the window of mouse event CHAR if any or the selected window.
+Return nil if CHAR is not a mouse event."
   (when (mouse-event-p char)
     (cond ((windowp (posn-window (event-start char)))
            (posn-window (event-start char)))
@@ -1605,7 +1605,8 @@ Which one depends on variable `subword-mode'."
 (defvar visual-line-mode)
 
 (defcustom avy-indent-line-overlay nil
-  "When non-nil, `avy-goto-line' will display the line overlay next to the first non-whitespace character of each line."
+  "When non-nil, display line overlay next to the first non-whitespace character.
+This affects `avy-goto-line'."
   :type 'boolean)
 
 (defun avy--line-cands (&optional arg beg end bottom-up)


### PR DESCRIPTION
This fixes two byte-compiler warnings in Emacs 28:

```
Compiling file /home/skangas/wip/emacs-packages/avy/avy.el at Sat Jan  1 04:13:22 2022
Entering directory ‘/home/skangas/wip/emacs-packages/avy/’

In avy-mouse-event-window:
avy.el:496:8: Warning: docstring wider than 80 characters
avy.el:1607:1: Warning: custom-declare-variable `avy-indent-line-overlay'
    docstring wider than 80 characters
```