### PR TITLE
Reverse the order of key-labels for "above" commands [#342]

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -405,7 +405,9 @@ KEYS are placed appropriately on internal nodes."
          (order-fn (cdr (assq avy-command avy-orders-alist)))
          (lst (if order-fn
                   (cl-sort lst #'< :key order-fn)
-                lst)))
+                (if (string-match-p "above" (symbol-name this-command))
+		    (nreverse lst)
+		  lst))))
     (cl-labels
         ((rd (ls)
            (let ((ln (length ls)))


### PR DESCRIPTION
Let's say I have a window showing many (200) lines. Point is somewhere
in the middle or bottom of the screen. I want to jump up say 5 lines.
Avy was optimized to jump most easily way up to the top of the window
rather than 5 lines up. To go upward, I almost always ended up typing
two prompt chars.

With the "above" cases for this commit, the order is now reversed,
going up 5 lines will always just require typing a single char to
jump. I feel that this should be the default behavior for the "above"
commands. Isn't it most common to do shorter jumps