### PR TITLE
Fix some byte-compiler warnings

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -1664,6 +1664,7 @@ When BOTTOM-UP is non-nil, display avy candidates from top to bottom"
 (defvar linum-overlays)
 (defvar linum-format)
 (declare-function linum--face-width "linum")
+(declare-function linum-mode "linum")
 
 (define-minor-mode avy-linum-mode
   "Minor mode that uses avy hints for `linum-mode'."

--- a/avy.el
+++ b/avy.el
@@ -395,7 +395,7 @@ SEQ-LEN is how many elements of KEYS it takes to identify a match."
 
 (defvar avy-command nil
   "Store the current command symbol.
-E.g. 'avy-goto-line or 'avy-goto-char.")
+E.g. `avy-goto-line' or `avy-goto-char'.")
 
 (defun avy-tree (lst keys)
   "Coerce LST into a balanced tree.
@@ -933,14 +933,14 @@ multiple OVERLAY-FN invocations."
         (null (assoc invisible buffer-invisibility-spec)))))
 
 (defun avy--next-visible-point ()
-  "Return the next closest point without 'invisible property."
+  "Return the next closest point without `invisible' property."
   (let ((s (point)))
     (while (and (not (= (point-max) (setq s (next-char-property-change s))))
                 (not (avy--visible-p s))))
     s))
 
 (defun avy--next-invisible-point ()
-  "Return the next closest point with 'invisible property."
+  "Return the next closest point with `invisible' property."
   (let ((s (point)))
     (while (and (not (= (point-max) (setq s (next-char-property-change s))))
                 (avy--visible-p s)))


### PR DESCRIPTION
Hi, thanks for avy.el!

The following PR fixes warnings that show up when byte-compilation. The first one is about how symbols should be quoted in docstrings:

This convention is documented in the Documentation Tips section of the Elisp manual

> • When a documentation string refers to a Lisp symbol, write it as it
>   would be printed (which usually means in lower case), with a grave
>   accent ‘`’ before and apostrophe ‘'’ after it.  There are two
>   exceptions: write ‘t’ and ‘nil’ without surrounding punctuation.

- https://www.gnu.org/software/emacs/manual/html_node/elisp/Documentation-Tips.html

The second one is about linum-mode not being known to be defined as the require happens when we execute the function.

The only warning that I didn't fix is the following:

> In avy--linum-update-window:
> avy.el:1723:14: Warning: ‘inhibit-point-motion-hooks’ is an obsolete variable
>     (as of 25.1); use ‘cursor-intangible-mode’ or ‘cursor-sensor-mode’ instead

Because using the new variable would mean dropping support for Emacs 24.1. Although I would be ok with that, I'm not sure how you feel about backwards compatibility. 