### PR TITLE
Fix invisibility check for some cases

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -928,11 +928,13 @@ multiple OVERLAY-FN invocations."
   (setq avy--overlays-back nil)
   (avy--remove-leading-chars))
 
+;; check for invisibility was taken from the Emacs function count-lines
 (defun avy--visible-p (s)
-  (let ((invisible (get-char-property s 'invisible)))
-    (or (null invisible)
-        (eq t buffer-invisibility-spec)
-        (null (assoc invisible buffer-invisibility-spec)))))
+  (let ((prop (get-char-property s 'invisible)))
+    (not (if (eq buffer-invisibility-spec t)
+             prop
+           (or (memq prop buffer-invisibility-spec)
+               (assq prop buffer-invisibility-spec))))))
 
 (defun avy--next-visible-point ()
   "Return the next closest point without `invisible' property."


### PR DESCRIPTION
Old `avy--visible-p` couldn't handle properly such case: `(get-char-property s 'invisible)` returns t;
`buffer-invisibility-spec` is set to `((outline . t) t)`

`from buffer-invisibility-spec` documentation:
```
The list can have two kinds of elements:
ATOM and (ATOM . ELLIPSIS).
A text character is invisible if its invisible property is ATOM 
```

Check for invisibility was taken from the Emacs function count-lines.