### PR TITLE
Fix typo in avy-kill-whole-line docstring

### DIFF
--- a/avy.el
+++ b/avy.el
@@ -2004,7 +2004,7 @@ selected line.  If ARG is negative, kill backward.
 If ARG is zero, kill the selected line but exclude the trailing
 newline.
 
-\\[universal-argument] 3 \\[avy-kil-whole-line] kill three lines
+\\[universal-argument] 3 \\[avy-kill-whole-line] kill three lines
 starting from the selected line.  \\[universal-argument] -3
 
 \\[avy-kill-whole-line] kill three lines backward including the


### PR DESCRIPTION
Corrects 'avy-kil-whole-line' to 'avy-kill-whole-line'.